### PR TITLE
escape $to, $username and $text from " to \"

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -27,5 +27,5 @@ fi
 message="${subject}: $3"
 
 # Build our JSON payload and send it as a POST request to the Slack incoming web-hook URL
-payload="payload={\"channel\": \"${to}\", \"username\": \"${username}\", \"text\": \"${message}\", \"icon_emoji\": \"${emoji}\"}"
+payload="payload={\"channel\": \"${to//\"/\\\"}\", \"username\": \"${username//\"/\\\"}\", \"text\": \"${message//\"/\\\"}\", \"icon_emoji\": \"${emoji}\"}"
 curl -m 5 --data-urlencode "${payload}" $url


### PR DESCRIPTION
When a message from Zabbix contains `"`, a JSON payload should be invalid.
We need to escape `"` as `\"`.