### PR TITLE
Additional configuration on Zabbix 3.0+ when creating the Media type

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Additionally, you can have multiple different Zabbix users each with "Slack" med
 Zabbix 3.0+: as of [dmaarten](https://github.com/damaarten "damaarten") In addition, on Zabbix version 3.0+, you need to specify 3 script parameters when creating the new media:
 
 Script parameters:
+
 	{ALERT.SENDTO}
 	{ALERT.SUBJECT}
 	{ALERT.MESSAGE}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Keeping the messages short is probably a good idea; use something such as the fo
 
 Additionally, you can have multiple different Zabbix users each with "Slack" media types that notify unique Slack users or channels upon different triggered Zabbix actions.
 
+Zabbix 3.0+: as of [dmaarten](https://github.com/damaarten "damaarten") In addition, on Zabbix version 3.0+, you need to specify 3 script parameters when creating the new media:
+
+Script parameters:
+	{ALERT.SENDTO}
+	{ALERT.SUBJECT}
+	{ALERT.MESSAGE}
+
+
 
 ## Testing
 


### PR DESCRIPTION
Pull request to add in README.md the information about Zabbix 3.0+ when creating Media Types, as of https://github.com/ericoc/zabbix-slack-alertscript/issues/10.